### PR TITLE
Postgres.app 2041425 fix

### DIFF
--- a/runner/src/main/scala/org/overviewproject/runner/commands/PostgresCommand.scala
+++ b/runner/src/main/scala/org/overviewproject/runner/commands/PostgresCommand.scala
@@ -33,6 +33,8 @@ object PostgresCommand {
     // Postgres.app, as per http://postgresapp.com/documentation
     "/Applications/Postgres.app/Contents/MacOS/bin",
     "/Applications/Postgres93.app/Contents/MacOS/bin",
+    // Postgres.app, as of 2014-04-25, has a different bin path
+    "/Applications/Postgres.app/Contents/Versions/9.3/bin",
     // Fink, according to http://pdb.finkproject.org/pdb/package.php/postgresql92
     "/sw/opt/postgresql-9.3/bin",
     "/sw/opt/postgresql-9.2/bin",


### PR DESCRIPTION
Instructions reference Postgres.app as the quickest/easiest way to get Postgres on Mac, but when you run ./dev, you get this error:

java.lang.Exception: Could not find Postgres 9.0-9.3. Please install initdb, postgres (which must be executable) in one of: /usr/bin, /bin, /usr/sbin, /sbin, /usr/local/bin, /usr/sbin, /usr/local/sbin, /usr/lib/postgresql/9.3/bin, /usr/lib/postgresql/9.2/bin, /usr/lib/postgresql/9.1/bin, /usr/lib/postgresql/9.0/bin, /usr/bin, /usr/local/bin, /usr/local/pgsql/bin, /opt/local/lib, /opt/local/lib/postgresql93/bin, /opt/local/lib/postgresql92/bin, /opt/local/lib/postgresql91/bin, /opt/local/lib/postgresql90/bin, /Applications/Postgres.app/Contents/MacOS/bin, /Applications/Postgres93.app/Contents/MacOS/bin, /sw/opt/postgresql-9.3/bin, /sw/opt/postgresql-9.2/bin, /sw/opt/postgresql-9.1/bin, /sw/opt/postgresql-9.0/bin, /opt/PostgreSQL/9.3/bin, /opt/PostgreSQL/9.2/bin, /opt/PostgreSQL/9.1/bin, /opt/PostgreSQL/9.0/bin, /Library/PostgreSQL/9.3/bin, /Library/PostgreSQL/9.2/bin, /Library/PostgreSQL/9.1/bin, /Library/PostgreSQL/9.0/bin

Looks like latest version of Postgres.app has the postgres/initdb/etc bins in a different dir than before. Added dir to PostgresCommand.scala and now Overview runs when I run ./dev
