### PR TITLE
fix for postgres server.key permissions.

### DIFF
--- a/runner/src/main/scala/org/overviewproject/runner/Database.scala
+++ b/runner/src/main/scala/org/overviewproject/runner/Database.scala
@@ -224,7 +224,7 @@ class Database(val file: File, val postgresqlConf: Seq[(String,InputStream)], va
       for (out <- managed(new FileWriter(file))) {
         out.write(contents)
         // server.key needs to be private, or Postgres won't start
-        Files.setPosixFilePermissions(Paths.get(file), PosixFilePermissions.fromString("rwxr-x---"))
+        Files.setPosixFilePermissions(Paths.get(file), PosixFilePermissions.fromString("rwx------"))
       }
     }
   }


### PR DESCRIPTION
Environment:
* MacOS X Yosemite 10.10.2
* java version "1.8.0_31"
* Postgres.app 9.4.1.0, downloaded earlier today from postgresapp.com

When running ./dev in overview-server directory, after downloading, running Postgres.app once, and then quitting, I get an error regarding permissions on a server.key file being incorrect.

From PostgresQL docs:
	http://www.postgresql.org/docs/9.1/static/ssl-tcp.html -- "On Unix systems, the permissions on server.key must disallow any access to world or group; achieve this by the command chmod 0600 server.key."
	http://www.postgresql.org/docs/9.2/static/ssl-tcp.html -- "On Unix systems, the permissions on server.key must disallow any access to world or group; achieve this by the command chmod 0600 server.key."
	http://www.postgresql.org/docs/9.3/static/ssl-tcp.html -- "On Unix systems, the permissions on server.key must disallow any access to world or group; achieve this by the command chmod 0600 server.key."
	http://www.postgresql.org/docs/9.4/static/ssl-tcp.html -- "On Unix systems, the permissions on server.key must disallow any access to world or group; achieve this by the command chmod 0600 server.key."

From Database.scala, line #227 :
	        Files.setPosixFilePermissions(Paths.get(file), PosixFilePermissions.fromString("rwxr-x---"))
I changed the permissions to "rwx------", rm -rf'd database/ directory, reran ./dev, and now it's moving past where it blew up before.

--cut output from ./dev--
[info] 	[SUCCESSFUL ] org.scalaz#scalaz-effect_2.10;7.0.4!scalaz-effect_2.10.jar(bundle) (318ms)
[info] Done updating.
[info] Compiling 16 Scala sources to /Users/sung/Development/overview-server/runner/target/scala-2.10/classes...
[info] Running org.overviewproject.runner.Main 
Preparing to start search-index, message-broker, overview-server, documentset-worker, redis, worker
[database] Running '/Applications/Postgres.app/Contents/Versions/9.4/bin/initdb' '-D' '/Users/sung/Development/overview-server/database' '-E' 'UTF8' '--no-locale' '-U' 'postgres'
[database] The files belonging to this database system will be owned by user "sung".
[database] This user must also own the server process.
[database] 
[database] The database cluster will be initialized with locale "C".
[database] The default text search configuration will be set to "english".
[database] 
[database] Data page checksums are disabled.
[database] 
[database] creating directory /Users/sung/Development/overview-server/database ... ok
[database] creating subdirectories ... ok
[database] selecting default max_connections ... 100
[database] selecting default shared_buffers ... 128MB
[database] selecting dynamic shared memory implementation ... posix
[database] creating configuration files ... ok
[database] creating template1 database in /Users/sung/Development/overview-server/database/base/1 ... ok
[database] initializing pg_authid ... ok
[database] initializing dependencies ... ok
[database] creating system views ... ok
[database] loading system objects' descriptions ... ok
[database] creating collations ... ok
[database] creating conversions ... ok
[database] creating dictionaries ... ok
[database] setting privileges on built-in objects ... ok
[database] creating information schema ... ok
[database] loading PL/pgSQL server-side language ... ok
[database] vacuuming database template1 ... ok
[database] copying template1 to template0 ... ok
[database] copying template1 to postgres ... ok
[database] 
[database] WARNING: enabling "trust" authentication for local connections
[database] You can change this by editing pg_hba.conf or using the option -A, or
[database] --auth-local and --auth-host, the next time you run initdb.
[database] syncing data to disk ... ok
[database] 
[database] Success. You can now start the database server using:
[database] 
[database]     /Applications/Postgres.app/Contents/Versions/9.4/bin/postgres -D /Users/sung/Development/overview-server/database
[database] or
[database]     /Applications/Postgres.app/Contents/Versions/9.4/bin/pg_ctl -D /Users/sung/Development/overview-server/database -l logfile start
[database] 
[database] created database in /Users/sung/Development/overview-server/database. Protect this directory! It contains your personal data.
[database] Wrote /Users/sung/Development/overview-server/database/postgresql.conf
[database] Wrote /Users/sung/Development/overview-server/database/server.crt
[database] Wrote /Users/sung/Development/overview-server/database/server.key
[database] Running '/Applications/Postgres.app/Contents/Versions/9.4/bin/postgres' '-D' '/Users/sung/Development/overview-server/database' '-k' '/Users/sung/Development/overview-server/database'
[database] pid=47438 xid=0 FATAL:  private key file "server.key" has group or world access
[database] pid=47438 xid=0 DETAIL:  Permissions should be u=rw (0600) or less.
[error] (run-main-0) org.postgresql.util.PSQLException: Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
org.postgresql.util.PSQLException: Connection refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
--end cut output from ./dev--
