### PR TITLE
New homepage video/copy

### DIFF
--- a/app/assets/javascripts/bundle/Welcome/show.coffee
+++ b/app/assets/javascripts/bundle/Welcome/show.coffee
@@ -16,4 +16,3 @@ require [
   'elements/form-submit-with-feedback'
   'bootstrap-alert'
 ], () ->
-  $('iframe.intro-video').attr('src', 'https://player.vimeo.com/video/71483614?byline=0&portrait=0&color=ffffff')

--- a/app/assets/stylesheets/Welcome/show.less
+++ b/app/assets/stylesheets/Welcome/show.less
@@ -51,8 +51,10 @@ body.welcome-show {
     margin-top: 2em;
   }
 
-  .splash>* {
-    text-align: left;
+  p.text {
+    // much better optical alignment with the overview logo,
+    // which has that big, round O skewing things visually.
+    padding: 0 20px;
   }
 
   article .col-md-6 {

--- a/app/views/Welcome/show.scala.html
+++ b/app/views/Welcome/show.scala.html
@@ -26,7 +26,9 @@
           </div>
           <div class="col-md-6">
             <div class="intro-video-wrapper">
-              <iframe class="intro-video" src="" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+              <iframe class="intro-video"
+                src="https://player.vimeo.com/video/129776851?byline=0&amp;portrait=0&amp;color=ffffff"
+                width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
             </div>
           </div>
         </div>

--- a/conf/messages
+++ b/conf/messages
@@ -232,7 +232,7 @@ views.DocumentCloudImportJob.new.submit_credentials.label=Verify DocumentCloud e
 
 views.DocumentCloudProject.index.title=DocumentCloud projects
 views.DocumentCloudProject.index.h1=DocumentCloud projects
-views.DocumentCloudProject.index.loading=Loading… 
+views.DocumentCloudProject.index.loading=Loading…
 views.DocumentCloudProject.index.help1=Overview can analyze and display your files from DocumentCloud. Import a project from this page.
 
 views.DocumentProcessingError.index.h4=Documents with errors
@@ -611,6 +611,6 @@ views.User.new.h1=Register
 
 views.Welcome.show.title=The Overview Project — Visualize your documents
 views.Welcome.show.h1=
-views.Welcome.show.p1=Read and analyze thousands of documents super quickly. Full text search, topic modeling, coding and tagging, visualizations and more. All in an easy-to use, visual workflow.
+views.Welcome.show.p1=Search, visualize, and review your documents. Up to hundreds of thousands of them, in any format.
 views.Welcome.show.learn=Learn more
 views.Welcome.show.warning_32bit_html=You are running Overview with 32-bit Java. This Java version prevents Overview from handling large document sets. Please read about <a href="https://github.com/overview/overview-server/wiki/Handling-huge-document-sets">handling large document sets</a>.


### PR DESCRIPTION
- Switches out the video url and the old copy
- Sets iframe's src attribute in HTML rather than JS (because why would we do this in JS?)
- Fixes the main text's optical alignment, and removes the unnecessary (and specific) `.splash > *` rule.